### PR TITLE
Update demo to use the official scrapegraph-py SDK (v2)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,11 +15,19 @@ We offer SDKs in both Python and Node.js, making it easy to integrate into your 
 
 | SDK       | Language | GitHub Link                                                                 |
 |-----------|----------|-----------------------------------------------------------------------------|
-| Python SDK | Python   | [scrapegraph-py](https://github.com/ScrapeGraphAI/scrapegraph-sdk/tree/main/scrapegraph-py) |
-| Node.js SDK | Node.js  | [scrapegraph-js](https://github.com/ScrapeGraphAI/scrapegraph-sdk/tree/main/scrapegraph-js) |
+| Python SDK | Python   | [scrapegraph-py](https://github.com/ScrapeGraphAI/scrapegraph-py) |
+| Node.js SDK | Node.js  | [scrapegraph-js](https://github.com/ScrapeGraphAI/scrapegraph-js) |
 
-## Official Demo for Scrapegraph-ai Library 
-This repo is a streamlit demo/trial for the offcial Github Library Scrapegraph-ai.
+## Official Demo for the ScrapeGraphAI Python SDK
+This repo is a Streamlit demo for the official [`scrapegraph-py`](https://github.com/ScrapeGraphAI/scrapegraph-py) SDK.
+The main page (`main.py`) calls the [ScrapeGraphAI API](https://scrapegraphai.com) through the SDK and showcases three services:
+
+- **Extract** — AI-structured data from a URL via a natural-language prompt (with an optional JSON schema)
+- **Scrape** — clean `markdown`, `html`, `links`, `images` or `summary` for a page
+- **Search** — search the web and optionally extract structured data from the results
+
+Grab an API key from the [dashboard](https://dashboard.scrapegraphai.com), paste it into the app, and run.
+See [`scrapegraph_py_example.py`](scrapegraph_py_example.py) for a minimal standalone SDK script.
 
 Link of the developed library for the hackathon Github repo:
 

--- a/main.py
+++ b/main.py
@@ -1,112 +1,211 @@
-import sys
-import asyncio
-
-if sys.platform.startswith("win"):
-    # On Windows, use the Proactor event loop, which supports subprocesses.
-    asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
-else:
-    # Optionally, you can use uvloop for better performance on Linux/macOS.
-    try:
-        import uvloop
-        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
-    except ImportError:
-        # uvloop isn't installed; continue with the default event loop.
-        pass
-
-import os
 import base64
-import streamlit as st
-import requests
 import json
+
 import pandas as pd
-from helper import (
-    playwright_install,
-    add_download_options
+import streamlit as st
+
+from scrapegraph_py import (
+    ScrapeGraphAI,
+    FetchConfig,
+    MarkdownFormatConfig,
+    HtmlFormatConfig,
+    LinksFormatConfig,
+    ImagesFormatConfig,
+    SummaryFormatConfig,
 )
 
-st.set_page_config(page_title="Scrapegraph-ai demo", page_icon="🕷️")
+st.set_page_config(page_title="ScrapeGraphAI demo", page_icon="🕷️")
 
-# Install playwright browsers
-playwright_install()
 
-def save_email(email):
-    with open("mails.txt", "a") as file:
-        file.write(email + "\n")
+def parse_schema(raw: str) -> dict | None:
+    """Parse an optional JSON schema entered by the user."""
+    raw = (raw or "").strip()
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        st.warning(f"Schema is not valid JSON, ignoring it: {exc}")
+        return None
+
+
+def render_download_buttons(payload, key: str) -> None:
+    """Offer JSON (always) and CSV (when tabular) downloads for a result."""
+    st.download_button(
+        label="Download JSON",
+        data=json.dumps(payload, indent=2, ensure_ascii=False),
+        file_name="scrapegraph_result.json",
+        mime="application/json",
+        key=f"json-{key}",
+    )
+    rows = payload if isinstance(payload, list) else [payload]
+    if rows and all(isinstance(r, dict) for r in rows):
+        try:
+            csv = pd.DataFrame(rows).to_csv(index=False)
+            st.download_button(
+                label="Download CSV",
+                data=csv,
+                file_name="scrapegraph_result.csv",
+                mime="text/csv",
+                key=f"csv-{key}",
+            )
+        except Exception:
+            pass
+
 
 with st.sidebar:
-    st.write("Official demo for [Scrapegraph-ai](https://github.com/VinciGit00/Scrapegraph-ai) library")
+    st.write(
+        "Official demo for the [scrapegraph-py]"
+        "(https://github.com/ScrapeGraphAI/scrapegraph-py) SDK."
+    )
     st.markdown("""---""")
-    st.write("# Usage Examples")
-    st.write("## Prompt 1")
-    st.write("- Give me all the news with their abstracts")
-    st.write("## Prompt 2")
-    st.write("- Create a voice summary of the webpage")
-    st.write("## Prompt 3")
-    st.write("- List me all the images with their visual description")
-    st.write("## Prompt 4")
-    st.write("- Read me the summary of the news")
+    st.write("# How it works")
+    st.write(
+        "This app calls the [ScrapeGraphAI API](https://scrapegraphai.com) "
+        "through the official Python SDK. Pick a service, paste your API key, "
+        "and run it:"
+    )
+    st.write("- **Extract** — AI-structured data from a URL via a prompt")
+    st.write("- **Scrape** — clean markdown / html / links / images / summary")
+    st.write("- **Search** — search the web and optionally extract data")
     st.markdown("""---""")
-    st.write("You want to suggest tips or improvements? Contact me through email to mvincig11@gmail.com")
+    st.write("Grab an API key on the [dashboard](https://dashboard.scrapegraphai.com).")
     st.markdown("""---""")
-    st.write("Follow our [Github page](https://github.com/ScrapeGraphAI)")
+    st.write("Follow us on [GitHub](https://github.com/ScrapeGraphAI)")
 
 
-st.title("Scrapegraph-ai")
+st.title("ScrapeGraphAI")
 left_co, cent_co, last_co = st.columns(3)
 with cent_co:
     st.image("assets/scrapegraphai_logo.png")
-st.title('Scrapegraph-api')
-st.write("### Refill at this page [Github page](https://scrapegraphai.com)")
+st.write("### Powered by the [scrapegraph-py](https://github.com/ScrapeGraphAI/scrapegraph-py) SDK")
 
-# Get the API key, URL, prompt, and optional schema from the user
-api_key = st.text_input('Enter your API key:', type="password")
-url = st.text_input('Enter the URL to scrape:')
-prompt = st.text_input('Enter your prompt:')
-schema = st.text_input('Enter your optional schema (leave blank if not needed):')
+api_key = st.text_input("Enter your API key:", type="password")
+service = st.radio("Service", ["Extract", "Scrape", "Search"], horizontal=True)
 
-# When the user clicks the 'Scrape' button
-if st.button('Scrape'):
-    if not api_key.startswith('sgai-'):
-        st.error("Invalid API key format. API key must start with 'sgai-'")
-    elif not url:
-        st.error("Please enter a URL to scrape")
-    elif not prompt:
-        st.error("Please enter a prompt")
-    else:
-        # Set up the headers and payload for the API request
-        headers = {
-            'accept': 'application/json',
-            'SGAI-APIKEY': api_key,
-            'Content-Type': 'application/json'
-        }
-        
-        payload = {
-            'website_url': url,
-            'user_prompt': prompt,
-            'type': 'object'
-        }
-        
-        # Add schema to payload if provided
-        if schema:
-            payload['schema'] = schema
 
-        try:
-            response = requests.post(
-                'https://api.scrapegraphai.com/v1/smartscraper',
-                headers=headers,
-                json=payload
-            )
-            
-            if response.status_code == 200:
-                data = response.json()
-                st.write("Result:", data)
+def get_client(key: str) -> ScrapeGraphAI:
+    return ScrapeGraphAI(api_key=key)
+
+
+def show_result(result, *, download_key: str, primary=None) -> None:
+    """Render an ApiResult: error, primary payload, raw JSON, downloads, timing."""
+    if result.status != "success":
+        st.error(result.error or "Request failed")
+        return
+    if primary is not None:
+        st.write(primary)
+        render_download_buttons(primary, download_key)
+    with st.expander("Raw response"):
+        st.json(result.data.model_dump(mode="json", by_alias=True))
+    st.caption(f"Completed in {result.elapsed_ms} ms")
+
+
+# --- Extract -----------------------------------------------------------------
+if service == "Extract":
+    url = st.text_input("URL to extract from:")
+    prompt = st.text_input("What do you want to extract?")
+    schema_raw = st.text_input("Optional JSON schema (leave blank if not needed):")
+
+    if st.button("Extract"):
+        if not (api_key or "").startswith("sgai-"):
+            st.error("Invalid API key format. API key must start with 'sgai-'")
+        elif not url:
+            st.error("Please enter a URL")
+        elif not prompt:
+            st.error("Please enter a prompt")
+        else:
+            with st.spinner("Extracting…"):
+                with get_client(api_key) as sgai:
+                    result = sgai.extract(
+                        prompt=prompt,
+                        url=url,
+                        schema=parse_schema(schema_raw),
+                    )
+            primary = None
+            if result.status == "success":
+                primary = result.data.json_data or result.data.raw
+            show_result(result, download_key="extract", primary=primary)
+
+# --- Scrape ------------------------------------------------------------------
+elif service == "Scrape":
+    url = st.text_input("URL to scrape:")
+    fmt_choice = st.selectbox(
+        "Format",
+        ["markdown", "html", "links", "images", "summary"],
+        index=0,
+    )
+    render_js = st.checkbox("Render JavaScript (slower, for dynamic pages)")
+
+    if st.button("Scrape"):
+        if not (api_key or "").startswith("sgai-"):
+            st.error("Invalid API key format. API key must start with 'sgai-'")
+        elif not url:
+            st.error("Please enter a URL")
+        else:
+            fmt_map = {
+                "markdown": MarkdownFormatConfig(),
+                "html": HtmlFormatConfig(),
+                "links": LinksFormatConfig(),
+                "images": ImagesFormatConfig(),
+                "summary": SummaryFormatConfig(),
+            }
+            fetch_config = FetchConfig(mode="js") if render_js else None
+            with st.spinner("Scraping…"):
+                with get_client(api_key) as sgai:
+                    result = sgai.scrape(
+                        url,
+                        formats=[fmt_map[fmt_choice]],
+                        fetch_config=fetch_config,
+                    )
+            primary = None
+            if result.status == "success":
+                entry = result.data.results.get(fmt_choice)
+                # markdown/html come back as {"data": ...}; links/images as lists
+                if isinstance(entry, dict) and "data" in entry:
+                    primary = entry["data"]
+                else:
+                    primary = entry
+                if isinstance(primary, list) and primary and isinstance(primary[0], str):
+                    primary = "\n".join(primary)
+            show_result(result, download_key="scrape", primary=primary)
+
+# --- Search ------------------------------------------------------------------
+else:
+    query = st.text_input("Search query:")
+    num_results = st.slider("Number of results", min_value=1, max_value=20, value=3)
+    prompt = st.text_input("Optional extraction prompt (leave blank for raw results):")
+
+    if st.button("Search"):
+        if not (api_key or "").startswith("sgai-"):
+            st.error("Invalid API key format. API key must start with 'sgai-'")
+        elif not query:
+            st.error("Please enter a search query")
+        else:
+            with st.spinner("Searching…"):
+                with get_client(api_key) as sgai:
+                    result = sgai.search(
+                        query,
+                        num_results=num_results,
+                        prompt=(prompt or None),
+                    )
+            if result.status == "success":
+                if result.data.json_data:
+                    st.write(result.data.json_data)
+                results = [r.model_dump(mode="json") for r in result.data.results]
+                for item in results:
+                    st.markdown(f"**[{item['title']}]({item['url']})**")
+                    st.write(item["content"][:500])
+                    st.markdown("---")
+                render_download_buttons(results, "search")
+                with st.expander("Raw response"):
+                    st.json(result.data.model_dump(mode="json", by_alias=True))
+                st.caption(f"Completed in {result.elapsed_ms} ms")
             else:
-                st.error(f"Error: {response.status_code} - {response.text}")
-                
-        except Exception as e:
-            st.error(f"Error: {str(e)}")
+                st.error(result.error or "Request failed")
 
 
+# --- Footer: social links ----------------------------------------------------
 left_co2, *_, cent_co2, last_co2, last_c3 = st.columns([1] * 18)
 
 with cent_co2:
@@ -120,7 +219,7 @@ with cent_co2:
     )
 
 with last_co2:
-    github_link = "https://github.com/VinciGit00/Scrapegraph-ai"
+    github_link = "https://github.com/ScrapeGraphAI/scrapegraph-py"
     github_logo = base64.b64encode(open("assets/github.png", "rb").read()).decode()
     st.markdown(
         f"""<a href="{github_link}" target="_blank">

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ boto3==1.35.36
 langchain_core==0.3.23
 pandas==2.2.3
 Requests==2.32.3
+scrapegraph-py>=2.2.0
 scrapegraphai==1.33.2
 streamlit==1.39.0

--- a/scrapegraph_py_example.py
+++ b/scrapegraph_py_example.py
@@ -1,1 +1,61 @@
- 
+"""Minimal, runnable tour of the scrapegraph-py SDK.
+
+Install the SDK and set your API key, then run this file:
+
+    pip install scrapegraph-py
+    export SGAI_API_KEY="sgai-..."   # or pass api_key=... to ScrapeGraphAI()
+    python scrapegraph_py_example.py
+
+Every SDK method returns an ``ApiResult`` with ``.status`` ("success" | "error"),
+``.data``, ``.error`` and ``.elapsed_ms`` — so there are no exceptions to catch.
+Docs: https://github.com/ScrapeGraphAI/scrapegraph-py
+"""
+
+import os
+
+from scrapegraph_py import ScrapeGraphAI, MarkdownFormatConfig
+
+
+def main() -> None:
+    # Reads SGAI_API_KEY from the environment, or pass api_key="sgai-..." here.
+    api_key = os.environ.get("SGAI_API_KEY")
+    sgai = ScrapeGraphAI(api_key=api_key)
+
+    # 1. Credits — check your remaining balance.
+    credits = sgai.credits()
+    if credits.status == "success":
+        print(f"Credits remaining: {credits.data.remaining}")
+
+    # 2. Extract — pull structured data from a URL with a natural-language prompt.
+    extract = sgai.extract(
+        prompt="Extract the page title and a one-sentence summary",
+        url="https://example.com",
+    )
+    if extract.status == "success":
+        print("Extract:", extract.data.json_data or extract.data.raw)
+    else:
+        print("Extract error:", extract.error)
+
+    # 3. Scrape — get clean markdown for a page.
+    scrape = sgai.scrape("https://example.com", formats=[MarkdownFormatConfig()])
+    if scrape.status == "success":
+        markdown = scrape.data.results.get("markdown", {}).get("data")
+        if isinstance(markdown, list):
+            markdown = "\n".join(markdown)
+        print("Scrape markdown:\n", (markdown or "")[:300])
+    else:
+        print("Scrape error:", scrape.error)
+
+    # 4. Search — search the web and optionally extract data from the results.
+    search = sgai.search("what is web scraping", num_results=3)
+    if search.status == "success":
+        for result in search.data.results:
+            print(f"- {result.title} — {result.url}")
+    else:
+        print("Search error:", search.error)
+
+    sgai.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What & why

The demo's main page called the legacy `/v1/smartscraper` REST endpoint by hand with `requests`. This PR migrates it to the official [`scrapegraph-py`](https://github.com/ScrapeGraphAI/scrapegraph-py) SDK (v2.2.0) against the v2 API, so the demo reflects how we actually recommend integrating today.

## Changes

- **`main.py`** — rewritten on `scrapegraph_py.ScrapeGraphAI` with a service selector exposing three modes:
  - **Extract** — AI-structured data from a URL via a prompt, with an optional JSON schema
  - **Scrape** — `markdown` / `html` / `links` / `images` / `summary`, with optional JS rendering (`FetchConfig(mode="js")`)
  - **Search** — web search with an optional extraction prompt
  
  Each mode renders the primary result, a collapsible raw response, JSON/CSV download buttons, and surfaces `ApiResult.error` / `elapsed_ms`. The client-side Playwright install is no longer needed (fetching happens server-side).
- **`scrapegraph_py_example.py`** — was an empty placeholder; now a runnable standalone tour (credits → extract → scrape → search).
- **`requirements.txt`** — add `scrapegraph-py>=2.2.0`.
- **`Readme.md`** — fix stale SDK repo links (`scrapegraph-sdk/tree/main/...` → `ScrapeGraphAI/scrapegraph-py` and `scrapegraph-js`) and describe the SDK-based demo.

## Testing

All four methods were exercised against the live v2 API (`extract`, `scrape`, `search`, `credits`, `health`) and the rendering paths (`json_data`, `results["markdown"|"links"].data`, `SearchResult.model_dump`, `model_dump(by_alias=True)`) were verified to match live response shapes. `scrapegraph_py_example.py` runs end-to-end; both files pass `py_compile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)